### PR TITLE
Implement FXML dialog for adding foods

### DIFF
--- a/src/main/resources/view/add_food_dialog.fxml
+++ b/src/main/resources/view/add_food_dialog.fxml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.collections.FXCollections?>
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.control.ComboBox?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.control.TextField?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.VBox?>
+
+<VBox alignment="CENTER" spacing="10" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1"
+      fx:controller="view.AddFoodDialogController">
+    <children>
+        <Label text="Add New Food Item" />
+        <Label text="Name:" />
+        <TextField fx:id="nameField" />
+        <Label text="Calories:" />
+        <TextField fx:id="caloriesField" />
+        <Label text="Protein (g):" />
+        <TextField fx:id="proteinField" />
+        <Label text="Fat (g):" />
+        <TextField fx:id="fatField" />
+        <Label text="Carbohydrates (g):" />
+        <TextField fx:id="carbsField" />
+        <Label text="Category:" />
+        <ComboBox fx:id="categoryBox">
+            <items>
+                <FXCollections fx:factory="observableArrayList">
+                    <String fx:value="Fruits" />
+                    <String fx:value="Vegetables" />
+                    <String fx:value="Meat" />
+                    <String fx:value="Dairy" />
+                    <String fx:value="Grains" />
+                </FXCollections>
+            </items>
+        </ComboBox>
+        <Label fx:id="errorLabel" textFill="RED" />
+        <HBox alignment="CENTER" spacing="10">
+            <children>
+                <Button text="Add" onAction="#handleAdd" />
+                <Button text="Cancel" onAction="#handleCancel" />
+            </children>
+        </HBox>
+    </children>
+    <padding>
+        <Insets top="15" right="15" bottom="15" left="15" />
+    </padding>
+</VBox>

--- a/src/main/scala/view/AddFoodDialogController.scala
+++ b/src/main/scala/view/AddFoodDialogController.scala
@@ -1,0 +1,63 @@
+package view
+
+import model.FoodItem
+import scalafx.scene.control.Alert
+import scalafx.scene.control.Alert.AlertType
+import scalafx.stage.Stage
+import javafx.fxml.FXML
+import javafx.scene.control.{TextField, ComboBox, Label}
+
+class AddFoodDialogController:
+
+  @FXML private var nameField: TextField = _
+  @FXML private var caloriesField: TextField = _
+  @FXML private var proteinField: TextField = _
+  @FXML private var fatField: TextField = _
+  @FXML private var carbsField: TextField = _
+  @FXML private var categoryBox: ComboBox[String] = _
+  @FXML private var errorLabel: Label = _
+
+  private var dialogStage: Stage = _
+  private var onAdd: FoodItem => Unit = _
+
+  def setDialogStage(stage: Stage): Unit =
+    dialogStage = stage
+
+  def setOnAdd(callback: FoodItem => Unit): Unit =
+    onAdd = callback
+
+  @FXML
+  private def handleAdd(): Unit =
+    val name = nameField.getText.trim
+    val caloriesText = caloriesField.getText.trim
+    val proteinText = proteinField.getText.trim
+    val fatText = fatField.getText.trim
+    val carbsText = carbsField.getText.trim
+    val category = Option(categoryBox.getValue)
+
+    if name.isEmpty || caloriesText.isEmpty || proteinText.isEmpty || fatText.isEmpty || carbsText.isEmpty || category.isEmpty then
+      errorLabel.setText("All fields must be filled.")
+    else if !caloriesText.forall(_.isDigit) || !proteinText.forall(c => c.isDigit || c == '.') || !fatText.forall(c => c.isDigit || c == '.') || !carbsText.forall(c => c.isDigit || c == '.') then
+      errorLabel.setText("Calories, protein, fat, and carbs must be numbers.")
+    else
+      val newItem = FoodItem(
+        id = 0,
+        name = name,
+        calories = caloriesText.toInt,
+        protein = proteinText.toDouble,
+        fat = fatText.toDouble,
+        carbs = carbsText.toDouble,
+        category = category.get
+      )
+      if onAdd != null then onAdd(newItem)
+      new Alert(AlertType.Information) {
+        title = "Success"
+        headerText = "Food Added"
+        contentText = s"$name has been added to the database."
+        initOwner(dialogStage)
+      }.showAndWait()
+      dialogStage.close()
+
+  @FXML
+  private def handleCancel(): Unit =
+    if dialogStage != null then dialogStage.close()

--- a/src/main/scala/view/AddFoodPopup.scala
+++ b/src/main/scala/view/AddFoodPopup.scala
@@ -1,83 +1,22 @@
 package view
 
-import scalafx.geometry.{Insets, Pos}
+import scalafx.stage.{Modality, Stage}
 import scalafx.scene.Scene
-import scalafx.scene.control._
-import scalafx.scene.layout.{VBox, HBox}
-import scalafx.stage.Stage
-import model.FoodItem
 import scalafx.Includes._
+import javafx.fxml.FXMLLoader
+import javafx.scene.Parent
+import model.FoodItem
 
 object AddFoodPopup:
 
   def show(onAdd: FoodItem => Unit): Unit =
+    val loader = new FXMLLoader(getClass.getResource("/view/add_food_dialog.fxml"))
+    val root: Parent = loader.load()
+    val controller = loader.getController[AddFoodDialogController]
     val stage = new Stage:
       title = "Add Food"
-
-    val nameField = new TextField()
-    val caloriesField = new TextField()
-    val proteinField = new TextField()
-    val fatField = new TextField()
-    val carbsField = new TextField()
-    val categoryBox = new ComboBox[String](List("Fruits", "Vegetables", "Meat", "Dairy", "Grains"))
-
-    val errorLabel = new Label("") {
-      style = "-fx-text-fill: red;"
-    }
-
-    val addButton = new Button("Add")
-    val cancelButton = new Button("Cancel")
-
-    addButton.onAction = _ =>
-      val name = nameField.text.value.trim
-      val caloriesText = caloriesField.text.value.trim
-      val proteinText = proteinField.text.value.trim
-      val fatText = fatField.text.value.trim
-      val carbsText = carbsField.text.value.trim
-      val category = categoryBox.value.value
-
-      // Validate input
-      if name.isEmpty || caloriesText.isEmpty || proteinText.isEmpty || fatText.isEmpty || carbsText.isEmpty || category == null then
-        errorLabel.text = "All fields must be filled."
-      else if !caloriesText.forall(_.isDigit) || !proteinText.forall(_.isDigit) || !fatText.forall(_.isDigit) || !carbsText.forall(_.isDigit) then
-        errorLabel.text = "Calories, protein, fat, and carbs must be numbers."
-      else
-        val newItem = FoodItem(
-          id = 0,
-          name = name,
-          calories = caloriesText.toInt,
-          protein = proteinText.toDouble,
-          fat = fatText.toDouble,
-          carbs = carbsText.toDouble,
-          category = category
-        )
-        onAdd(newItem)
-        val alert = new Alert(Alert.AlertType.Information):
-          title = "Success"
-          headerText = "Food Added"
-          contentText = s"$name has been added to the database."
-        alert.showAndWait()
-        stage.close()
-
-    cancelButton.onAction = _ => stage.close()
-
-    val form = new VBox(10):
-      padding = Insets(15)
-      alignment = Pos.Center
-      children = List(
-        new Label("Add New Food Item"),
-        new Label("Name:"), nameField,
-        new Label("Calories:"), caloriesField,
-        new Label("Protein (g):"), proteinField,
-        new Label("Fat (g):"), fatField,
-        new Label("Carbohydrates (g):"), carbsField,
-        new Label("Category:"), categoryBox,
-        errorLabel,
-        new HBox(10) {
-          alignment = Pos.Center
-          children = List(addButton, cancelButton)
-        }
-      )
-
-    stage.scene = new Scene(form, 300, 500)
+      scene = new Scene(root)
+      initModality(Modality.ApplicationModal)
+    controller.setDialogStage(stage)
+    controller.setOnAdd(onAdd)
     stage.showAndWait()


### PR DESCRIPTION
## Summary
- Replace programmatic add-food popup with FXMLLoader-backed dialog
- Implement AddFoodDialogController with @FXML bindings and validation
- Define add_food_dialog.fxml layout in resources

## Testing
- `./sbt -no-colors test`

------
https://chatgpt.com/codex/tasks/task_e_6893766a0e1883339c4d2d79a9126a06